### PR TITLE
fix: fightParam not applying correctly

### DIFF
--- a/era/front.js
+++ b/era/front.js
@@ -28,13 +28,14 @@ function loadPage() {
 
     if (idParam) {
         document.getElementById("reportSelect").value = idParam;
-        selectReport();
-    }
-
-    if (fightParam) {
-        let selectedIndex = parseInt(fightParam);
-        sleep(5000);
-        selectFight(selectedIndex);
+        selectReport().then(function() {
+            if (fightParam) {
+                const fightIndex = parseInt(fightParam) - 1;
+                const el_fightSelect = document.getElementById("fightSelect");
+                el_fightSelect.value = el_fightSelect.options[fightIndex].value;
+                selectFight();
+            }
+        })
     }
 
     if (enemyParam) {

--- a/era/threat.js
+++ b/era/threat.js
@@ -859,7 +859,7 @@ function selectReport() {
     el.style.borderColor = null;
     if (!(reportId in reports)) reports[reportId] = new Report(reportId);
     enableInput(false);
-    reports[reportId].fetch().then(() => {
+    return reports[reportId].fetch().then(() => {
         for (let id in reports[reportId].fights) {
             let f = reports[reportId].fights[id];
             let el_f = document.createElement("option");


### PR DESCRIPTION
**Context**
- `sleep(5000)` doesn't actually wait for the next line since it only returns a Promise.
- It's faster and more reliable to selectFight when selectReport is finished than waiting for fixed 5 seconds

**Changes**
- threat.js
  - selectReport now returns a Promise
- front.js
  - apply fightParam after selectReport is resolved
  - fightParam is a 1-base index so convert it to 0-base fightIndex.
  - change the value of #fightSelect so the UI shows which fight's selected