### PR TITLE
[Era] Extract initialBuffs config, allow spellId buff multipliers

### DIFF
--- a/era/spells.js
+++ b/era/spells.js
@@ -240,7 +240,20 @@ const auraImplications = {
         9846: 768, //Tiger's Fury
         1850: 768, 9821: 768, //Dash
     }
-}
+};
+
+/** 
+ * Allows one to check the combatantInfo and infer buffs and talents. 
+ * 
+ * Here is a good place to check gear and apply Tier set bonus buffs. e.g. Check for 2pc gear, apply
+ * the buff. Then, in buffMultipliers, you can apply global coefficients or to specific spells.
+ */
+const combatantImplications = {
+  All: (info, buffs, talents) => {
+    // set via buffs[id] = true;
+  },
+  Warrior: (combatantInfo, buffs, talents) => {},
+};
 
 const threatFunctions = {
     sourceThreatenTarget(ev, fight, amount, useThreatCoeffs = true, extraCoeff = 1) { // extraCoeff is only used for tooltip text

--- a/era/spells.js
+++ b/era/spells.js
@@ -28,6 +28,24 @@ const baseThreatCoefficients = {
     // Others will be defaulted to 1
 }
 
+/** Sets certain buffs to always show as toggles per class */
+const initialBuffs = {
+  All: {1038: 0, 25895: 0, 25909: 0},
+  Paladin: {
+    25780: 0,
+  },
+  Warrior: {
+    71: 0,		// Stances
+    2457: 0,
+    2458: 0,
+  },
+  Druid: {
+    5487: 0,	// Forms
+    9634: 0,
+    768: 0,
+  }
+};
+
 const buffNames = {
     1038: "Blessing of Salvation",
     25895: "Greater Blessing of Salvation",

--- a/era/threat.js
+++ b/era/threat.js
@@ -818,10 +818,8 @@ class Report {
                 }
             }
             // Add class-specific initial buff settings
-            if (initialBuffs[f.type]) {
-                for (let initialBuffId in initialBuffs[f.type]) {
-                    f.initialBuffs[initialBuffId] = initialBuffs[f.type][initialBuffId];
-                } 
+            if (typeof initialBuffs[f.type] === 'object') {
+                f.initialBuffs = {...f.initialBuffs, ...initialBuffs[f.type]};
             }
             
             // Get faction

--- a/era/threat.js
+++ b/era/threat.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const throttleTime = 250;
+const throttleTime = 150;
 let apikey = "b91955fd65954650000220e85bd79c3d";
 let plotXRange = [-Infinity, Infinity];
 let plotData = [];
@@ -42,8 +42,7 @@ async function fetchWCLv1(path) {
 async function fetchWCLreport(path, start, end) {
     let t = start;
     let events = [];
-    let width = end - start;
-    let filter = encodeURI(`type IN ("death","cast","begincast") OR ability.id IN (${Object.keys(notableBuffs).join(',')}) OR (type IN ("damage","heal","miss","applybuff","applybuffstack","refreshbuff","applydebuff","applydebuffstack","refreshdebuff","resourcechange","absorbed","healabsorbed","leech","drain") AND ability.id NOT IN (${zeroThreatSpells.join(",")}))`);
+    let filter = encodeURI(`type IN ("death","cast","begincast") OR ability.id IN (${Object.keys(notableBuffs).join(',')}) OR (type IN ("damage","heal","healing","miss","applybuff","applybuffstack","refreshbuff","applydebuff","applydebuffstack","refreshdebuff","resourcechange","absorbed","healabsorbed","leech","drain", "removebuff") AND ability.id NOT IN (${zeroThreatSpells.join(",")}))`);
     while (typeof t === "number") {
         let json = await fetchWCLv1(`report/events/${path}&start=${t}&end=${end}&filter=${filter}`);
         if (!json.events) throw "Could not parse report " + path;
@@ -51,6 +50,51 @@ async function fetchWCLreport(path, start, end) {
         t = json.nextPageTimestamp;
     }
     return events;
+}
+
+async function fetchWCLDebuffs(path, start, end, abilityId, stack) {
+
+    let t = start;
+    let auras = [];
+    while (typeof t === "number") {
+        let query = `report/tables/debuffs/${path}&start=${t}&end=${end}&hostility=1&abilityid=${abilityId}`;
+        if (stack) {
+            query = query + `&filter=stack%3D${stack}`
+        }
+        let json = await fetchWCLv1(query);
+        if (!json.auras) throw "Could not parse report " + path;
+        auras.push(...json.auras);
+        t = json.nextPageTimestamp;
+    }
+    return auras;
+}
+
+async function fetchWCLCombatantInfo(path, start, end) {
+
+    let t = start;
+    let events = [];
+    while (typeof t === "number") {
+        let filter = encodeURI(`type IN ("combatantinfo")`);
+        let query = `report/events/${path}&start=${t}&end=${end}&filter=${filter}`;
+        let json = await fetchWCLv1(query);
+        if (!json.events) throw "Could not parse report " + path;
+        events.push(...json.events);
+        t = json.nextPageTimestamp;
+    }
+    return events;
+}
+
+async function fetchWCLPlayerBuffs(path, start, end, source) {
+    let t = start;
+    let auras = [];
+    while (typeof t === "number") {
+        let query = `report/tables/buffs/${path}&start=${t}&end=${end}&hostility=0&targetid=${source}`;
+        let json = await fetchWCLv1(query);
+        if (!json.auras) throw "Could not parse report " + path;
+        auras.push(...json.auras);
+        t = json.nextPageTimestamp;
+    }
+    return auras;
 }
 
 class ThreatTrace {
@@ -296,11 +340,6 @@ class Unit {
         let spellSchool = ability ? ability.type : this.spellSchool;
         let spellId = ability ? ability.guid : null;
         let c = this.baseThreatCoeff(spellSchool);
-        if (this.buffs[29232]) {
-            if (spellId !== 1) {
-                //return 0;
-            }
-        }
         for (let i in this.buffs) {
             if (i in buffMultipliers) {
               if (typeof buffMultipliers[i] === 'function') {
@@ -369,14 +408,19 @@ class Unit {
 
 // Class for players and pets
 class Player extends Unit {
-    constructor(key, info, events, tranquilAir = false) {
+    constructor(key, info, events, combatantInfos, tranquilAir  = false) {
         super(key, info.name, info.type, events);
         this.global = info;
         this.talents = info.talents;
+        this.combatantInfos = combatantInfos;
+
         console.assert("initialBuffs" in info, "Player info not properly initialised.", info);
+        
         this.checkWarrior(events); // Extra stance detection
         this.checkPaladin(events); // Extra Righteous Fury detection
         this.checkFaction(tranquilAir); // BoS and tranquil air
+        this.checkInitalStatus(); // Check gear (enchants), talents and initial buffs
+
         let a = info.initialBuffs;
         for (let k in a) {
             if (a[k] === 1) {
@@ -392,6 +436,19 @@ class Player extends Unit {
 
     isBuffInferred(buffId) {
         return (this.global.initialBuffs[buffId] - 3) % 3 >= 0;
+    }
+
+    checkInitalStatus() {
+        for (const c of this.combatantInfos) {
+            // initial auras
+            if (c?.auras) {
+                for (const aura of c.auras) {
+                    this.buffs[aura.ability] = true;
+                }
+            }
+            combatantImplications.All?.(c, this.buffs, this.talents);
+            combatantImplications[this.type]?.(c, this.buffs, this.talents);
+        }
     }
 
     // Blessing of Salvation and Tranquil Air detection
@@ -602,11 +659,15 @@ class Fight {
         this.faction = faction;
         this.reportId = reportId;
         this.tranquilAir = false;
+        this.combatantInfos = [];
     }
 
     async fetch() {
         if ("events" in this) return;
         this.events = await fetchWCLreport(this.reportId + "?", this.start, this.end);
+        if (this.combatantInfos.length === 0) {
+          this.combatantInfos = await fetchWCLCombatantInfo(this.reportId + "?", this.start, this.end);
+        }
         // Custom events
         if (this.encounter === 791) { // High Priestess Arlokk
             let u;
@@ -655,7 +716,7 @@ class Fight {
             if (t === "NPC" || t === "Boss" || t === "Pet") {
                 a[k] = new NPC(k, u, this.events, this);
             } else {
-                a[k] = new Player(k, this.globalUnits[id], this.events, this.tranquilAir);
+                a[k] = new Player(k, this.globalUnits[id], this.events, this.combatantInfos.filter(i => i.sourceID === Number(id)), this.tranquilAir);
             }
             this.units[k] = a[k];
         }


### PR DESCRIPTION
- Extract out initialBuffs, so we can add more per-class ones in spells.js and keep them out of threat.js 
   - Will be used in SoD, but can work in era if we need
- Allow a buffMultiplier to apply only to certain spells via a fucntion
   ```js
   [BuffId]: {
      coef(buffs, spellId) {
        if (SomeOtherBuffId in buffs and spellId in spellsThatGetMod) {
          return getThreatCoefficient(1.5); 
        }
        return getThreatCoefficient(1); 
      }
    }
   ```
- Added a fetch of `combatantinfo` when fetching a fight. This makes for better initial aura detection, and allows this ->
- Added a `combatantImplications` structure so we can check gear and talents to infer buffs or other coefficients
   ```js
   const combatantImplications = {
     All: (unit, buffs) => {
       if (unit.gear.some(g => g.permanentEnchant === Items.Enchant.GlovesThreat)) {
         buffs[Items.Enchant.GlovesThreat] = true;
       }
     },
     Warrior: (unit, buffs, talents) => {},
   };
   ```