### PR TITLE
[Era/SoD] Extract handlers from threat.js into spellFunctions

### DIFF
--- a/era/spells.js
+++ b/era/spells.js
@@ -300,6 +300,33 @@ const combatantImplications = {
 const spellFunctions = {
   18670: handler_bossDropThreatOnHit(0.5), // Broodlord Knock Away
   23339: handler_bossDropThreatOnHit(0.5), // BWL Wing Buffet
+  // Nefarian's warrior class call, force Berserker Stance
+  23397: (ev, fight) => {
+    const target = fight.eventToUnit(ev, "target");
+    if (ev.type === "applydebuff") {
+      delete target.buffs[71];
+      delete target.buffs[2457];
+      target.buffs[2458] = true; // Berserker stance
+    }
+
+    if (ev.type === "removedebuff") {
+      delete target.buffs[2458];
+    }
+  },
+  // Nefarian's Druid class call, force Cat form
+  23398: (ev, fight) => {
+    const target = fight.eventToUnit(ev, "target");
+    if (ev.type === "applydebuff") {
+      delete target.buffs[5487]; // Bear form
+      delete target.buffs[9634]; // Dire Bear form
+      target.buffs[768] = true; // Cat form
+    }
+
+    if (ev.type === "removedebuff") {
+      delete target.buffs[768];
+    }
+  },
+
   18392: handler_bossDropThreatOnCast(0), // Onyxia Fireball
   19633: handler_bossDropThreatOnHit(0.75), // Onyxia Knock Away
   20534: handler_bossDropThreatOnCast(0), // Majordomo Teleport

--- a/era/threat.js
+++ b/era/threat.js
@@ -859,30 +859,6 @@ class Fight {
           if (!(i in notableBuffs)) break;
           u = this.eventToUnit(ev, "target");
           if (!u) break;
-          if (i === 23397 && ev.type === "applydebuff") {
-            // Special handler for Nefarian's warrior class call
-            delete u.buffs[71];
-            delete u.buffs[2457];
-            u.buffs[2458] = true;
-          }
-          if (i === 23398 && ev.type === "applydebuff") {
-            // Druid class call
-            delete u.buffs[5487];
-            delete u.buffs[9634];
-            u.buffs[768] = true;
-          }
-          if (i === 29232 && ev.type === "applydebuff") {
-            // Fungal Bloom
-            if (u.type !== "Mage") {
-              u.buffs[29232] = true;
-            } else {
-              u.buffs[29232] = false;
-            }
-          }
-          if (i === 29232 && ev.type === "removedebuff") {
-            // Fungal Bloom
-            u.buffs[29232] = false;
-          }
           u.buffs[i] = true;
           [_, enemies] = this.eventToFriendliesAndEnemies(ev, "target");
           for (let k in enemies) {
@@ -917,10 +893,6 @@ class Fight {
               ev.ability.name + " fades",
               u.threatCoeff()
             );
-          }
-          if (i === 23398) {
-            // Druid class call
-            delete u.buffs[768];
           }
           delete u.buffs[i];
           if (i in fixateBuffs) {

--- a/sod/spells.js
+++ b/sod/spells.js
@@ -67,6 +67,7 @@ const buffMultipliers = {
   ...priest.buffMultipliers,
   [Items.Enchant.GlovesThreat]: getThreatCoefficient(Items.Mods.GlovesThreat),
   [Items.Enchant.CloakSubtlety]: getThreatCoefficient(Items.Mods.CloakSubtlety),
+  29232: getThreatCoefficient(0), // Fungal Bloom
 };
 
 // The leaf elements are functions (buffs,rank) => threatCoefficient

--- a/sod/spells.js
+++ b/sod/spells.js
@@ -188,6 +188,33 @@ const spellFunctions = {
   ...priest.spellFunctions,
   18670: handler_bossDropThreatOnHit(0.5), // Broodlord Knock Away
   23339: handler_bossDropThreatOnHit(0.5), // BWL Wing Buffet
+  // Nefarian's warrior class call, force Berserker Stance
+  23397: (ev, fight) => {
+    const target = fight.eventToUnit(ev, "target");
+    if (ev.type === "applydebuff") {
+      delete target.buffs[71];
+      delete target.buffs[2457];
+      target.buffs[2458] = true; // Berserker stance
+    }
+
+    if (ev.type === "removedebuff") {
+      delete target.buffs[2458];
+    }
+  },
+  // Nefarian's Druid class call, force Cat form
+  23398: (ev, fight) => {
+    const target = fight.eventToUnit(ev, "target");
+    if (ev.type === "applydebuff") {
+      delete target.buffs[5487]; // Bear form
+      delete target.buffs[9634]; // Dire Bear form
+      target.buffs[768] = true; // Cat form
+    }
+
+    if (ev.type === "removedebuff") {
+      delete target.buffs[768];
+    }
+  },
+
   18392: handler_bossDropThreatOnCast(0), // Onyxia Fireball
   19633: handler_bossDropThreatOnHit(0.75), // Onyxia Knock Away
   20534: handler_bossDropThreatOnCast(0), // Majordomo Teleport


### PR DESCRIPTION
This allows the threat.js to be generic and allows us to configure game version specific stuff in spells.js