### PR TITLE
[Era/SoD] Add a coefficient debug mode

### DIFF
--- a/era/front.js
+++ b/era/front.js
@@ -400,7 +400,7 @@ function plot(config, reportId, fight, enemy) {
       }<br>Threat: ${threatDiff.toFixed(1)}<br>Total: ${unitInfo.threat[
         i
       ].toFixed(1)}`;
-      if (unitInfo.coeff[i] && unitInfo.coeff[i].value) {
+      if (unitInfo.coeff[i]?.value !== undefined) {
         text += "<br>Coeff: " + unitInfo.coeff[i].value.toFixed(2);
         if (
           unitInfo.coeff[i].value !== 1 &&

--- a/era/front.js
+++ b/era/front.js
@@ -471,13 +471,18 @@ function plot(config, reportId, fight, enemy) {
     colorByClass = x;
     recolorPlot();
   });
-  createCheckbox(el_div, debugCoefficients, "Debug coefficients", (v) => {
-    debugCoefficients = v;
-    localStorage.setItem(
-      "debugCoefficients",
-      JSON.stringify(debugCoefficients)
-    );
-  });
+  createCheckbox(
+    el_div,
+    debugCoefficients,
+    "Display detailed coefficients",
+    (v) => {
+      debugCoefficients = v;
+      localStorage.setItem(
+        "debugCoefficients",
+        JSON.stringify(debugCoefficients)
+      );
+    }
+  );
   if (fight.faction == "Horde")
     createCheckbox(
       el_div,

--- a/era/front.js
+++ b/era/front.js
@@ -9,6 +9,9 @@ let plotXRange = [-Infinity, Infinity];
 let recolorPlot = () => {};
 let colorByClass = true;
 
+/** Shows extra coefficient info in the plot tooltip */
+let debugCoefficients = localStorage.getItem("debugCoefficients") === "true";
+
 const SCROLLBAR_WIDTH = 16;
 
 /**
@@ -347,7 +350,7 @@ function enableInput(enable = true) {
  * @param {Element | null} el_out
  * @param {boolean} checked
  * @param {string | null} text
- * @param {{ (x: any): void; (x: any): void; (arg0: boolean): any; }} callback
+ * @param {(val: boolean) => void} callback
  */
 export function createCheckbox(el_out, checked, text, callback) {
   let el_checkbox = document.createElement("input");
@@ -397,18 +400,27 @@ function plot(config, reportId, fight, enemy) {
       }<br>Threat: ${threatDiff.toFixed(1)}<br>Total: ${unitInfo.threat[
         i
       ].toFixed(1)}`;
-      if (unitInfo.coeff[i] !== null)
-        text += "<br>Coeff: " + unitInfo.coeff[i].toFixed(2);
+      if (unitInfo.coeff[i] && unitInfo.coeff[i].value) {
+        text += "<br>Coeff: " + unitInfo.coeff[i].value.toFixed(2);
+        if (
+          unitInfo.coeff[i].value !== 1 &&
+          unitInfo.coeff[i].debug &&
+          debugCoefficients
+        ) {
+          text +=
+            "<br><br>" +
+            unitInfo.coeff[i].debug
+              .map(({ value, label }) => `- ${label}: ${value.toFixed(2)}`)
+              .join("<br>");
+        }
+      }
       if (unitInfo.fixateHistory[i])
         text += "<br>Fixate: " + unitInfo.fixateHistory[i];
       if (unitInfo.invulnerabilityHistory[i].length)
         text +=
           "<br>Invulnerability: " +
           unitInfo.invulnerabilityHistory[i]
-            .map(
-              (/** @type {string | number} */ x) =>
-                config.invulnerabilityBuffs[x]
-            )
+            .map((/** @type {number} */ x) => config.invulnerabilityBuffs[x])
             .join("+");
       texts.push(text);
     }
@@ -455,15 +467,17 @@ function plot(config, reportId, fight, enemy) {
     }
     globalThis.Plotly.restyle(el_plot, { "marker.color": colors });
   };
-  createCheckbox(
-    el_div,
-    colorByClass,
-    "Color by class",
-    (/** @type {any} */ x) => {
-      colorByClass = x;
-      recolorPlot();
-    }
-  );
+  createCheckbox(el_div, colorByClass, "Color by class", (x) => {
+    colorByClass = x;
+    recolorPlot();
+  });
+  createCheckbox(el_div, debugCoefficients, "Debug coefficients", (v) => {
+    debugCoefficients = v;
+    localStorage.setItem(
+      "debugCoefficients",
+      JSON.stringify(debugCoefficients)
+    );
+  });
   if (fight.faction == "Horde")
     createCheckbox(
       el_div,

--- a/era/threat/fight.js
+++ b/era/threat/fight.js
@@ -2,6 +2,10 @@ import { fetchWCLreport, fetchWCLCombatantInfo } from "./wcl.js";
 import { Unit, Player, NPC } from "./unit.js";
 import { handler_basic, handler_mark, threatFunctions } from "../base.js";
 
+/**
+ * @typedef {'source' | 'target'} UnitSpecifier
+ */
+
 export class Fight {
   /**
    * @param {import("../base.js").GameVersionConfig} config
@@ -87,8 +91,12 @@ export class Fight {
     }
   }
 
+  /**
+   * @param {import("./wcl.js").WCLEvent} ev
+   * @param {UnitSpecifier} unit
+   * @returns {Unit | undefined}
+   */
   eventToUnit(ev, unit) {
-    // Unit should be "source" or "target"
     // TODO: Fix units that are both enemies and friends in a single fight
     let k = Unit.eventToKey(ev, unit);
     if (!k || k == -1) return;
@@ -120,6 +128,11 @@ export class Fight {
     return this.units[k];
   }
 
+  /**
+   * @param {import("./wcl.js").WCLEvent} ev
+   * @param {UnitSpecifier} unit
+   * @returns {[Record<string, Unit>, Record<string, Unit>]}
+   */
   eventToFriendliesAndEnemies(ev, unit) {
     let friendly = ev[unit + "IsFriendly"];
     let friendlies = friendly ? this.friendlies : this.enemies;

--- a/era/threat/wcl.js
+++ b/era/threat/wcl.js
@@ -113,3 +113,109 @@ async function fetchWCLPlayerBuffs(path, start, end, source) {
   }
   return auras;
 }
+
+/**
+ * @typedef {{
+ *   guid: number;
+ *   type: number;
+ *   name: string;
+ *   abilityIcon: string;
+ * }} WCLAbility
+ */
+
+/**
+ * @typedef {{
+ *   amount: number;
+ *   cost: number;
+ *   max: number;
+ *   type: number;
+ * }} Resource
+ */
+
+/**
+ * @typedef {WCLHealEvent | WCLApplyBuffEvent | WCLRemoveBuffEvent | WCLApplyDebuffEvent | WCLRemoveDebuffEvent} WCLEvent
+ */
+
+/**
+ * @typedef {{
+ *   type: "heal";
+ *   ability: WCLAbility;
+ *   absorb: number;
+ *   amount: number;
+ *   armor: number;
+ *   attackPower: number;
+ *   avoidance: number;
+ *   classResources: Resource[];
+ *   facing: number;
+ *   fight: number;
+ *   hitPoints: number;
+ *   hitType: number;
+ *   itemLevel: number;
+ *   mapID: number;
+ *   maxHitPoints: number;
+ *   overheal: number;
+ *   resourceActor: number;
+ *   sourceID: number;
+ *   sourceIsFriendly: boolean;
+ *   spellPower: number;
+ *   targetID: number;
+ *   targetIsFriendly: boolean;
+ *   tick: boolean;
+ *   timestamp: number;
+ *   versatility: number;
+ *   x: number;
+ *   y: number;
+ * }} WCLHealEvent
+ */
+
+/**
+ * @typedef {{
+ *   type: "applybuff";
+ *   ability: WCLAbility;
+ *   fight: number;
+ *   sourceID: number;
+ *   sourceIsFriendly: boolean;
+ *   targetID: number;
+ *   targetIsFriendly: boolean;
+ *   timestamp: number;
+ * }} WCLApplyBuffEvent
+ */
+
+/**
+ * @typedef {{
+ *   type: "removedebuff";
+ *   ability: WCLAbility;
+ *   fight: number;
+ *   sourceID: number;
+ *   sourceIsFriendly: boolean;
+ *   targetID: number;
+ *   targetIsFriendly: boolean;
+ *   timestamp: number;
+ * }} WCLRemoveDebuffEvent
+ */
+
+/**
+ * @typedef {{
+ *   type: "applydebuff";
+ *   ability: WCLAbility;
+ *   fight: number;
+ *   sourceID: number;
+ *   sourceIsFriendly: boolean;
+ *   targetID: number;
+ *   targetIsFriendly: boolean;
+ *   timestamp: number;
+ * }} WCLApplyDebuffEvent
+ */
+
+/**
+ * @typedef {{
+ *   type: "removebuff";
+ *   ability: WCLAbility;
+ *   fight: number;
+ *   sourceID: number;
+ *   sourceIsFriendly: boolean;
+ *   targetID: number;
+ *   targetIsFriendly: boolean;
+ *   timestamp: number;
+ * }} WCLRemoveBuffEvent
+ */

--- a/sod/spells.js
+++ b/sod/spells.js
@@ -91,6 +91,7 @@ export const buffNames = {
   [Items.Enchant.GlovesThreat]: "Enchant Gloves - Threat",
   [Items.Enchant.CloakSubtlety]: "Enchant Cloak - Subtlety",
   [Items.Buff.EyeOfDiminution]: "The Eye of Diminution",
+  29232: "Fungal Bloom",
 };
 
 export const buffMultipliers = {


### PR DESCRIPTION
This is helpful in seeing the full stack of coefficients.

A lot of this change was adding type hints so that I could see where all the changes needed to be made.

I wasn't able to make this trigger easily via an alt key or modifier. For now it's a checkbox that remembers it's value in `localStorage`

<img width="306" alt="Screenshot 2025-02-19 at 1 02 16 PM" src="https://github.com/user-attachments/assets/1eee5323-51de-4c2e-ba0e-1df8ba0aab4a" />


As you can see here, we can see that it's applying two stance coefficients.. so we have a bug in stance application logic.

<img width="284" alt="Screenshot 2025-02-19 at 1 03 18 PM" src="https://github.com/user-attachments/assets/d9d12b62-2e46-4b17-87ee-323977b34b69" />


<img width="295" alt="Screenshot 2025-02-19 at 1 31 45 PM" src="https://github.com/user-attachments/assets/14727da5-4330-478e-a115-ab709681c278" />

Also fixed displaying 0 coefficients:
<img width="396" alt="Screenshot 2025-02-19 at 1 32 59 PM" src="https://github.com/user-attachments/assets/23583da7-b954-41de-b595-9a864763d99a" />



