### PR TITLE
[Naxx 1] More Naxx tests

### DIFF
--- a/_test/helpers.ts
+++ b/_test/helpers.ts
@@ -1,0 +1,34 @@
+import { Page } from "@playwright/test";
+
+/**
+ * Loads a target from a report.
+ *
+ * Run the local server with `npm run start`
+ *
+ * @param page - The Playwright Page
+ * @param url - The URL of the report.
+ * @param unitKey - The `fight;enemy;target` key to select
+ */
+export async function loadTargetFromReport(
+  page: Page,
+  url: string,
+  unitKey: string
+) {
+  const [, reportId] = /reports\/(\w+)$/.exec(url)!;
+
+  await page.goto(url);
+
+  if (reportId) {
+    const [fightId, enemyId, targetId] = unitKey.split(";");
+    await page.locator("#fightSelect").selectOption(`${reportId};${fightId}`);
+
+    await page.getByRole("button", { name: "Fetch/Refresh" }).click();
+
+    await page
+      .locator("#enemySelect")
+      .selectOption(`${reportId};${fightId};${enemyId}`);
+    await page
+      .locator("#targetSelect")
+      .selectOption(`${reportId};${fightId};${enemyId};${targetId}`);
+  }
+}

--- a/era/era-threat.spec.ts
+++ b/era/era-threat.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import { loadTargetFromReport } from "../_test/helpers";
 
+// Run the local server with `npm run start`
 test.describe("/era/ threat values", () => {
   test("Warrior Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
       "1;43;38" // Anub'Rekhan - Tragortf
     );
 
@@ -32,7 +34,7 @@ test.describe("/era/ threat values", () => {
   test("Mage - Fire", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
       "1;43;9" // Anub'Rekhan - Chosme
     );
 
@@ -57,7 +59,7 @@ test.describe("/era/ threat values", () => {
   test("Warrior DPS", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
       "1;43;30" // Anub'Rekhan - Rouguishh
     );
 
@@ -85,7 +87,7 @@ test.describe("/era/ threat values", () => {
   test("Warlock", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
       "1;43;10" // Anub'Rekhan - Lysten
     );
 
@@ -106,7 +108,7 @@ test.describe("/era/ threat values", () => {
   test("Rogue", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
       "1;43;20" // Anub'Rekhan - Gwumpyx
     );
 
@@ -132,7 +134,7 @@ test.describe("/era/ threat values", () => {
   test("Hunter", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
       "28;101;4" // Nefarian - Marìa
     );
 
@@ -156,7 +158,7 @@ test.describe("/era/ threat values", () => {
   test("Druid - Cat", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
       "28;101;14" // Nefarian - Thallack
     );
 
@@ -181,7 +183,7 @@ test.describe("/era/ threat values", () => {
   test("Druid - Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/WXKGAVjrx3D2vqw6",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/WXKGAVjrx3D2vqw6",
       "24;90;14" // Ebonroc - Miskovsky
     );
 
@@ -207,7 +209,7 @@ test.describe("/era/ threat values", () => {
   test("Mage - Frost", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
       "28;101;25" // Nefarian - Bleshat
     );
 
@@ -226,86 +228,4 @@ test.describe("/era/ threat values", () => {
           - row "Total 40434.70 415.41"
       `);
   });
-
-  test.describe("special threat mechanics", () => {
-    test("BWL - Nefarian - Warrior class call", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
-        "28;101;32" // Nefarian - Amí
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-        - textbox
-        - text: "Amí - Started fight with threat coeff 1.495"
-        - table:
-            - rowgroup:
-                - row "Ability        Threat (*)  Per 97.34 seconds"
-            - row "Heroic Strike	90313.28	927.84"
-            - row "Melee	36150.53	371.40"
-            - row "Execute	35584.00	365.58"
-            - row "Bloodthirst	18217.89	187.16"
-            - row "Revenge	8543.92	87.78"
-            - row "Electric Discharge	1523.25	15.65"
-            - row "Whirlwind	480.00	4.93"
-            - row "Sunder Armor	390.19	4.01"
-            - row "Judgement of Light	302.74	3.11"
-            - row "Unbridled Wrath	170.11	1.75"
-            - row "Bloodrage	70.00	0.72"
-            - row "Demoralizing Shout	64.29	0.66"
-            - row "Total	191810.21	1970.58"
-        `);
-    });
-
-    test("BWL - Nefarian - Druid class call", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://vanilla.warcraftlogs.com/reports/WXKGAVjrx3D2vqw6",
-        "31;110;14" // Nefarian - Miskovsky
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-        - textbox
-        - text: "Miskovsky - Started fight with threat coeff 1.45"
-        - table:
-            - rowgroup:
-                - row "Ability        Threat (*)  Per 123.61 seconds"
-            - row "Maul	86615.03	700.72"
-            - row "Melee	18594.81	150.43"
-            - row "Shred	4518.44	36.55"
-            - row "Ferocious Bite	1569.81	12.70"
-            - row "Faerie Fire (Feral)	1406.16	11.38"
-            - row "Claw	329.44	2.67"
-            - row "Swipe	296.89	2.40"
-            - row "Furor	120.83	0.98"
-            - row "Earthstrike	29.00	0.23"
-            - row "Slayer's Crest	29.00	0.23"
-            - row "Total	113509.41	918.30"
-        `);
-    });
-  });
 });
-
-async function loadTargetFromReport(
-  page: Page,
-  reportUrl: string,
-  unitKey: string
-) {
-  const [, reportId] = /reports\/(\w+)/.exec(reportUrl)!;
-
-  await page.goto(`/era/?id=${reportId}`);
-
-  if (reportId) {
-    const [fightId, enemyId, targetId] = unitKey.split(";");
-    await page.locator("#fightSelect").selectOption(`${reportId};${fightId}`);
-
-    await page.getByRole("button", { name: "Fetch/Refresh" }).click();
-
-    await page
-      .locator("#enemySelect")
-      .selectOption(`${reportId};${fightId};${enemyId}`);
-    await page
-      .locator("#targetSelect")
-      .selectOption(`${reportId};${fightId};${enemyId};${targetId}`);
-  }
-}

--- a/era/era.spec.ts
+++ b/era/era.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+// Run the local server with `npm run start`
+
 const TEST_LOG_URL =
   "https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt";
 

--- a/era/raid/bwl.spec.ts
+++ b/era/raid/bwl.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { loadTargetFromReport } from "../../_test/helpers";
+
+// Run the local server with `npm run start`
+test.describe("/era/ threat values - BWL mechanics", () => {
+  test("BWL - Nefarian - Warrior class call", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/kTAJXcx7P6ZnrjbG",
+      "28;101;32" // Nefarian - Amí
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+        - textbox
+        - text: "Amí - Started fight with threat coeff 1.495"
+        - table:
+            - rowgroup:
+                - row "Ability        Threat (*)  Per 97.34 seconds"
+            - row "Heroic Strike	90313.28	927.84"
+            - row "Melee	36150.53	371.40"
+            - row "Execute	35584.00	365.58"
+            - row "Bloodthirst	18217.89	187.16"
+            - row "Revenge	8543.92	87.78"
+            - row "Electric Discharge	1523.25	15.65"
+            - row "Whirlwind	480.00	4.93"
+            - row "Sunder Armor	390.19	4.01"
+            - row "Judgement of Light	302.74	3.11"
+            - row "Unbridled Wrath	170.11	1.75"
+            - row "Bloodrage	70.00	0.72"
+            - row "Demoralizing Shout	64.29	0.66"
+            - row "Total	191810.21	1970.58"
+        `);
+  });
+
+  test("BWL - Nefarian - Druid class call", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/WXKGAVjrx3D2vqw6",
+      "31;110;14" // Nefarian - Miskovsky
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+        - textbox
+        - text: "Miskovsky - Started fight with threat coeff 1.45"
+        - table:
+            - rowgroup:
+                - row "Ability        Threat (*)  Per 123.61 seconds"
+            - row "Maul	86615.03	700.72"
+            - row "Melee	18594.81	150.43"
+            - row "Shred	4518.44	36.55"
+            - row "Ferocious Bite	1569.81	12.70"
+            - row "Faerie Fire (Feral)	1406.16	11.38"
+            - row "Claw	329.44	2.67"
+            - row "Swipe	296.89	2.40"
+            - row "Furor	120.83	0.98"
+            - row "Earthstrike	29.00	0.23"
+            - row "Slayer's Crest	29.00	0.23"
+            - row "Total	113509.41	918.30"
+        `);
+  });
+});

--- a/era/raid/naxx.spec.ts
+++ b/era/raid/naxx.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+import { loadTargetFromReport } from "../../_test/helpers";
+
+// Run the local server with `npm run start`
+test.describe("/era/ threat values - Naxx mechanics", () => {
+  test("Patchwerk - Hateful Strike", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "22;223;31" // Patchwerk - Wftestthree
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Wftestthree - Started fight with threat coeff 1.0465"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 81.30 seconds"
+          - row "Heroic Strike	73234.07	900.84"
+          - row "Hateful Strike	31200.00	383.79"
+          - row "Bloodthirst	14979.90	184.27"
+          - row "Revenge	10888.46	133.94"
+          - row "Gift of Arthas	1614.60	19.86"
+          - row "Battle Shout	1601.15	19.70"
+          - row "Melee	830.32	10.21"
+          - row "Sunder Armor	780.39	9.60"
+          - row "Bloodrage	157.13	1.93"
+          - row "Unbridled Wrath	93.25	1.15"
+          - row "Kiss of the Spider	89.70	1.10"
+          - row "Total	135468.96	1666.39"
+      `);
+  });
+
+  test("Thaddius - Feugen - Magnetic pull", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "28;233;38" // Thaddius - Feugen - Tragortf
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Tragortf - Started fight with threat coeff 1.495"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 131.78 seconds"
+          - row "Magnetic Pull	36823.47	279.43"
+          - row "Heroic Strike	9194.25	69.77"
+          - row "Melee	2514.59	19.08"
+          - row "Bloodthirst	1474.82	11.19"
+          - row "Revenge	992.31	7.53"
+          - row "Sunder Armor	390.19	2.96"
+          - row "Judgement of Light	60.17	0.46"
+          - row "Bloodrage	56.06	0.43"
+          - row "Battle Shout	44.85	0.34"
+          - row "Unbridled Wrath	30.00	0.23"
+          - row "Total	51580.72	391.42"
+      `);
+  });
+
+  test("4HM - Zeliek - Mark of Zeliek", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "20;205;37" // 4HM - Zeliek - Znipsqt
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Znipsqt - Started fight with threat coeff 1.495"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 70.61 seconds"
+          - row "Heroic Strike	51238.13	725.64"
+          - row "Melee	22773.34	322.52"
+          - row "Bloodthirst	11976.45	169.61"
+          - row "Revenge	2280.62	32.30"
+          - row "Sunder Armor	1170.58	16.58"
+          - row "Taunt	852.28	12.07"
+          - row "Goblin Sapper Charge	810.29	11.48"
+          - row "Deep Wound	432.05	6.12"
+          - row "Judgement of Light	122.96	1.74"
+          - row "Unbridled Wrath	41.67	0.59"
+          - row "Battle Shout	22.42	0.32"
+          - row "Slayer's Crest	22.42	0.32"
+          - row "Bloodrage	18.69	0.26"
+          - row "Mark of Zeliek	-74033.55	-1048.47"
+          - row "Total	17728.37	251.07"
+      `);
+  });
+
+  test("Loatheb - Fungal Bloom", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/era/?id=https://vanilla.warcraftlogs.com/reports/qXDrpmFfHg3dNjzt",
+      "12;107;9" // Loatheb - Chosme
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Chosme - Started fight with threat coeff 0.49"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 94.06 seconds"
+          - row "Ignite	136149.93	1447.48"
+          - row "Scorch	27152.37	288.67"
+          - row "Fireball	18161.85	193.09"
+          - row "Pyroblast	2148.65	22.84"
+          - row "Master of Elements	1046.50	11.13"
+          - row "Clearcasting	113.40	1.21"
+          - row "Combustion	88.20	0.94"
+          - row "Essence of Sapphiron	42.00	0.45"
+          - row "Blink	33.60	0.36"
+          - row "Melee	30.80	0.33"
+          - row "Total	184967.30	1966.48"
+      `);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: "./tests",
+  testDir: "./",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/sod/raid/naxx.spec.ts
+++ b/sod/raid/naxx.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import { loadTargetFromReport } from "../../_test/helpers";
+
+// Run the local server with `npm run start`
+test.describe("/sod/ threat values - Naxx mechanics", () => {
+  test("Patchwerk - Warrior - MT", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/ZGqcXNWmHKRPb842",
+      "53;129;7" // Patchwerk - Enzad
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Enzad - Started fight with threat coeff 0.56"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 71.61 seconds"
+          - row "Heroic Strike	146113.73	2040.32"
+          - row "Shield Slam	132125.59	1844.99"
+          - row "Devastate	70653.86	986.61"
+          - row "Deep Wound	48671.08	679.64"
+          - row "Revenge	37232.68	519.92"
+          - row "Damage Shield Dmg +80	25357.90	354.10"
+          - row "Execute	24587.50	343.34"
+          - row "Melee	23597.00	329.51"
+          - row "Splintered Shield	17134.62	239.27"
+          - row "Hateful Strike	6400.00	89.37"
+          - row "Sunder Armor	5598.97	78.18"
+          - row "Gift of Arthas	1335.24	18.65"
+          - row "Wild Strike	856.56	11.96"
+          - row "Defender's Resolve	751.20	10.49"
+          - row "Defensive Forecast	287.04	4.01"
+          - row "Gri'lek's Guard	221.76	3.10"
+          - row "Bloodrage	169.70	2.37"
+          - row "Battle Forecast	134.40	1.88"
+          - row "Greater Stoneshield	71.76	1.00"
+          - row "Rampage	71.76	1.00"
+          - row "Total	541372.33	7559.69"
+      `);
+  });
+
+  test("Patchwerk - Warlock - Hateful target", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/ZGqcXNWmHKRPb842",
+      "53;129;21" // Patchwerk - Baldbulla
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Baldbulla - Started fight with threat coeff 1.239"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 71.61 seconds"
+          - row "Searing Pain	243904.58	3405.87"
+          - row "Shadow Cleave	30054.42	419.68"
+          - row "Hateful Strike	4800.00	67.03"
+          - row "Melee	3931.35	54.90"
+          - row "Drain Life	3434.51	47.96"
+          - row "Dance of the Wicked	2150.28	30.03"
+          - row "Shadow and Flame	1263.78	17.65"
+          - row "Defender's Resolve	669.06	9.34"
+          - row "Spreading Pain	669.06	9.34"
+          - row "Demonic Grace	446.04	6.23"
+          - row "Fel Armor	301.70	4.21"
+          - row "The Burrower's Shell	74.34	1.04"
+          - row "Total	291699.12	4073.27"
+      `);
+  });
+
+  test("Patchwerk - Rogue MT", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/CNXHnFyDbqkahWpx",
+      "44;160;8" // Patchwerk - Dedgame
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Dedgame - Started fight with threat coeff 1.9097"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 74.48 seconds"
+          - row "Sinister Strike	358072.43	4807.44"
+          - row "Melee	294122.09	3948.85"
+          - row "Unfair Advantage	175395.60	2354.84"
+          - row "Eviscerate	138233.35	1855.90"
+          - row "Riposte	47605.56	639.15"
+          - row "Blunderbuss	28244.80	379.21"
+          - row "Hateful Strike	24000.00	322.22"
+          - row "Damage Shield Dmg +80	19246.18	258.40"
+          - row "Poisoned Knife	17819.62	239.24"
+          - row "Occult Poison II	16001.56	214.84"
+          - row "Main Gauche	12848.61	172.50"
+          - row "Blood Barrier	8425.70	113.12"
+          - row "Rolling with the Punches	8135.42	109.23"
+          - row "Relentless Strikes Effect	2240.00	30.07"
+          - row "Wild Strike	1947.92	26.15"
+          - row "Gift of Arthas	1203.13	16.15"
+          - row "Burst of Energy	650.00	8.73"
+          - row "Strikes of the Sinister	572.92	7.69"
+          - row "Defender's Resolve	343.75	4.62"
+          - row "Blade Dance	343.75	4.62"
+          - row "Slice and Dice	229.17	3.08"
+          - row "Evasion	114.58	1.54"
+          - row "Blade Flurry	114.58	1.54"
+          - row "Total	1155910.72	15519.12"
+      `);
+  });
+
+  test("Patchwerk - Shaman - Hateful target", async ({ page }) => {
+    await loadTargetFromReport(
+      page,
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/CNXHnFyDbqkahWpx",
+      "44;160;15" // Patchwerk - Dedgame
+    );
+
+    await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
+      - textbox
+      - text: "Tombah - Started fight with threat coeff 1.45"
+      - table:
+          - rowgroup:
+              - row "Ability        Threat (*)  Per 74.48 seconds"
+          - row "Earth Shock	221192.28	2969.70"
+          - row "Lava Burst	157718.82	2117.51"
+          - row "Flame Shock	137968.08	1852.34"
+          - row "Lightning Shield	59093.88	793.39"
+          - row "Melee	38137.32	512.03"
+          - row "Damage Shield Dmg +80	22999.32	308.79"
+          - row "Splintered Shield	16138.50	216.67"
+          - row "Dragonbreath Chili	13709.46	184.06"
+          - row "Shamanistic Rage	11141.40	149.58"
+          - row "Hateful Strike	5600.00	75.18"
+          - row "Maelstrom Weapon	4698.00	63.07"
+          - row "Defender's Resolve	2610.00	35.04"
+          - row "Shield Mastery	1825.80	24.51"
+          - row "Elemental Devastation	939.60	12.61"
+          - row "Stormbraced	626.40	8.41"
+          - row "Flurry	522.00	7.01"
+          - row "Clearcasting	208.80	2.80"
+          - row "Maelstrom Ready!	208.80	2.80"
+          - row "Total	695338.46	9335.53"
+      `);
+  });
+});

--- a/sod/sod-threat.spec.ts
+++ b/sod/sod-threat.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import { loadTargetFromReport } from "../_test/helpers";
 
+// Run the local server with `npm run start`
 test.describe("/sod/ threat values", () => {
   test("Warrior Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "3;36;9" // The Prophet Skeram - Sheenftw
     );
 
@@ -41,7 +43,7 @@ test.describe("/sod/ threat values", () => {
   test("Druid Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/kTf82pHyXPwKtR41",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/kTf82pHyXPwKtR41",
       "43;102;23" // Heigan the Unclean - Lucyol
     );
 
@@ -76,7 +78,7 @@ test.describe("/sod/ threat values", () => {
   test("Paladin Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "20;92;5" // Princess Huhuran - Neitsa
     );
 
@@ -113,7 +115,7 @@ test.describe("/sod/ threat values", () => {
   test("Rogue Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/3kQ6nRY7W4fdtMJ8",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/3kQ6nRY7W4fdtMJ8",
       "4;36;23" // The Prophet Skeram - Jaistyr
     );
 
@@ -153,7 +155,7 @@ test.describe("/sod/ threat values", () => {
   test("Shaman Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/GKfj9q83Yw1vBVkc",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/GKfj9q83Yw1vBVkc",
       "3;87;6" // Anub'Rekhan - Predasmoke
     );
 
@@ -193,7 +195,7 @@ test.describe("/sod/ threat values", () => {
   test("Warlock Tank", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/vjbpBYnLQDxqcw1P",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/vjbpBYnLQDxqcw1P",
       "11;80;7" // Anub'Rekhan - Dagreât
     );
 
@@ -227,7 +229,7 @@ test.describe("/sod/ threat values", () => {
   test("Ret Pally", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "3;36;1" // The Prophet Skeram - Ascherìt
     );
 
@@ -263,7 +265,7 @@ test.describe("/sod/ threat values", () => {
   test("Hunter", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "3;36;15" // The Prophet Skeram - Madbulltwo
     );
 
@@ -295,7 +297,7 @@ test.describe("/sod/ threat values", () => {
   test("Rogue", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "3;36;24" // The Prophet Skeram - Danstonass
     );
 
@@ -333,7 +335,7 @@ test.describe("/sod/ threat values", () => {
   test("Warrior - DPS", async ({ page }) => {
     await loadTargetFromReport(
       page,
-      "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
+      "http://127.0.0.1:8080/sod/?id=https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN",
       "3;36;10" // The Prophet Skeram - Absÿ
     );
 
@@ -370,171 +372,4 @@ test.describe("/sod/ threat values", () => {
           - row "Total	139151.72	1298.24"
       `);
   });
-
-  test.describe("special threat mechanics", () => {
-    test("Patchwerk - Warrior - MT", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://sod.warcraftlogs.com/reports/ZGqcXNWmHKRPb842",
-        "53;129;7" // Patchwerk - Enzad
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-      - textbox
-      - text: "Enzad - Started fight with threat coeff 0.56"
-      - table:
-          - rowgroup:
-              - row "Ability        Threat (*)  Per 71.61 seconds"
-          - row "Heroic Strike	146113.73	2040.32"
-          - row "Shield Slam	132125.59	1844.99"
-          - row "Devastate	70653.86	986.61"
-          - row "Deep Wound	48671.08	679.64"
-          - row "Revenge	37232.68	519.92"
-          - row "Damage Shield Dmg +80	25357.90	354.10"
-          - row "Execute	24587.50	343.34"
-          - row "Melee	23597.00	329.51"
-          - row "Splintered Shield	17134.62	239.27"
-          - row "Hateful Strike	6400.00	89.37"
-          - row "Sunder Armor	5598.97	78.18"
-          - row "Gift of Arthas	1335.24	18.65"
-          - row "Wild Strike	856.56	11.96"
-          - row "Defender's Resolve	751.20	10.49"
-          - row "Defensive Forecast	287.04	4.01"
-          - row "Gri'lek's Guard	221.76	3.10"
-          - row "Bloodrage	169.70	2.37"
-          - row "Battle Forecast	134.40	1.88"
-          - row "Greater Stoneshield	71.76	1.00"
-          - row "Rampage	71.76	1.00"
-          - row "Total	541372.33	7559.69"
-      `);
-    });
-
-    test("Patchwerk - Warlock - Hateful target", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://sod.warcraftlogs.com/reports/ZGqcXNWmHKRPb842",
-        "53;129;21" // Patchwerk - Baldbulla
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-      - textbox
-      - text: "Baldbulla - Started fight with threat coeff 1.239"
-      - table:
-          - rowgroup:
-              - row "Ability        Threat (*)  Per 71.61 seconds"
-          - row "Searing Pain	243904.58	3405.87"
-          - row "Shadow Cleave	30054.42	419.68"
-          - row "Hateful Strike	4800.00	67.03"
-          - row "Melee	3931.35	54.90"
-          - row "Drain Life	3434.51	47.96"
-          - row "Dance of the Wicked	2150.28	30.03"
-          - row "Shadow and Flame	1263.78	17.65"
-          - row "Defender's Resolve	669.06	9.34"
-          - row "Spreading Pain	669.06	9.34"
-          - row "Demonic Grace	446.04	6.23"
-          - row "Fel Armor	301.70	4.21"
-          - row "The Burrower's Shell	74.34	1.04"
-          - row "Total	291699.12	4073.27"
-      `);
-    });
-
-    test("Patchwerk - Rogue MT", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://sod.warcraftlogs.com/reports/CNXHnFyDbqkahWpx",
-        "44;160;8" // Patchwerk - Dedgame
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-      - textbox
-      - text: "Dedgame - Started fight with threat coeff 1.9097"
-      - table:
-          - rowgroup:
-              - row "Ability        Threat (*)  Per 74.48 seconds"
-          - row "Sinister Strike	358072.43	4807.44"
-          - row "Melee	294122.09	3948.85"
-          - row "Unfair Advantage	175395.60	2354.84"
-          - row "Eviscerate	138233.35	1855.90"
-          - row "Riposte	47605.56	639.15"
-          - row "Blunderbuss	28244.80	379.21"
-          - row "Hateful Strike	24000.00	322.22"
-          - row "Damage Shield Dmg +80	19246.18	258.40"
-          - row "Poisoned Knife	17819.62	239.24"
-          - row "Occult Poison II	16001.56	214.84"
-          - row "Main Gauche	12848.61	172.50"
-          - row "Blood Barrier	8425.70	113.12"
-          - row "Rolling with the Punches	8135.42	109.23"
-          - row "Relentless Strikes Effect	2240.00	30.07"
-          - row "Wild Strike	1947.92	26.15"
-          - row "Gift of Arthas	1203.13	16.15"
-          - row "Burst of Energy	650.00	8.73"
-          - row "Strikes of the Sinister	572.92	7.69"
-          - row "Defender's Resolve	343.75	4.62"
-          - row "Blade Dance	343.75	4.62"
-          - row "Slice and Dice	229.17	3.08"
-          - row "Evasion	114.58	1.54"
-          - row "Blade Flurry	114.58	1.54"
-          - row "Total	1155910.72	15519.12"
-      `);
-    });
-
-    test("Patchwerk - Shaman - Hateful target", async ({ page }) => {
-      await loadTargetFromReport(
-        page,
-        "https://sod.warcraftlogs.com/reports/CNXHnFyDbqkahWpx",
-        "44;160;15" // Patchwerk - Dedgame
-      );
-
-      await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
-      - textbox
-      - text: "Tombah - Started fight with threat coeff 1.45"
-      - table:
-          - rowgroup:
-              - row "Ability        Threat (*)  Per 74.48 seconds"
-          - row "Earth Shock	221192.28	2969.70"
-          - row "Lava Burst	157718.82	2117.51"
-          - row "Flame Shock	137968.08	1852.34"
-          - row "Lightning Shield	59093.88	793.39"
-          - row "Melee	38137.32	512.03"
-          - row "Damage Shield Dmg +80	22999.32	308.79"
-          - row "Splintered Shield	16138.50	216.67"
-          - row "Dragonbreath Chili	13709.46	184.06"
-          - row "Shamanistic Rage	11141.40	149.58"
-          - row "Hateful Strike	5600.00	75.18"
-          - row "Maelstrom Weapon	4698.00	63.07"
-          - row "Defender's Resolve	2610.00	35.04"
-          - row "Shield Mastery	1825.80	24.51"
-          - row "Elemental Devastation	939.60	12.61"
-          - row "Stormbraced	626.40	8.41"
-          - row "Flurry	522.00	7.01"
-          - row "Clearcasting	208.80	2.80"
-          - row "Maelstrom Ready!	208.80	2.80"
-          - row "Total	695338.46	9335.53"
-      `);
-    });
-  });
 });
-
-async function loadTargetFromReport(
-  page: Page,
-  reportUrl: string,
-  unitKey: string
-) {
-  const [, reportId] = /reports\/(\w+)/.exec(reportUrl)!;
-
-  await page.goto(`/sod/?id=${reportId}`);
-
-  if (reportId) {
-    const [fightId, enemyId, targetId] = unitKey.split(";");
-    await page.locator("#fightSelect").selectOption(`${reportId};${fightId}`);
-
-    await page.getByRole("button", { name: "Fetch/Refresh" }).click();
-
-    await page
-      .locator("#enemySelect")
-      .selectOption(`${reportId};${fightId};${enemyId}`);
-    await page
-      .locator("#targetSelect")
-      .selectOption(`${reportId};${fightId};${enemyId};${targetId}`);
-  }
-}

--- a/sod/sod.spec.ts
+++ b/sod/sod.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+// Run the local server with `npm run start`
+
 const TEST_LOG_URL = "https://sod.warcraftlogs.com/reports/JvA4KLpyZ1fxrPgN";
 
 test.describe("/sod/", () => {


### PR DESCRIPTION
This will make way for an extraction of raid/naxx.js from era/spells so that we can extend it and change it for SoD.

Writing the tests now so we can see changes in isolation.

Changes:

- Moved tests into sod/, era/ dirs
- Use full urls in the test so they can act as links and you can click on them in the IDE to get updated values
- Split raid mechanic checks into raid/*.spec.ts so that we can be more clear why we're testing things
<pr-train-toc>

|     | PR  | Description                           |
| --- | --- | ------------------------------------- |
| 👉  | #36 | [Naxx 1] More naxx mechanics tests    |
|     | #37 | [Naxx 2] Extract Era Naxx config      |
|     | #38 | [Naxx 3] Era Fungal Bloom             |
|     | #39 | [Naxx 4] SoD Sanctified buff handling |

</pr-train-toc>