### PR TITLE
[Era/SoD] Fix starting coefficient

### DIFF
--- a/era/raid/naxx.js
+++ b/era/raid/naxx.js
@@ -2,6 +2,7 @@ import {
   handler_bossThreatWipeOnCast,
   handler_bossPartialThreatWipeOnCast,
   handler_taunt,
+  getThreatCoefficient,
 } from "../base.js";
 
 export const config = {
@@ -15,7 +16,7 @@ export const buffNames = {
 };
 
 export const buffMultipliers = {
-  // [config.Buff.FungalBloom]: getThreatCoefficient(0), 		// Fungal Bloom
+  [config.Buff.FungalBloom]: getThreatCoefficient(0), // Fungal Bloom
 };
 
 export const fixateBuffs = {

--- a/era/raid/naxx.spec.ts
+++ b/era/raid/naxx.spec.ts
@@ -102,17 +102,13 @@ test.describe("/era/ threat values - Naxx mechanics", () => {
       - table:
           - rowgroup:
               - row "Ability        Threat (*)  Per 94.06 seconds"
-          - row "Ignite	136149.93	1447.48"
-          - row "Scorch	27152.37	288.67"
-          - row "Fireball	18161.85	193.09"
-          - row "Pyroblast	2148.65	22.84"
           - row "Master of Elements	1046.50	11.13"
-          - row "Clearcasting	113.40	1.21"
-          - row "Combustion	88.20	0.94"
+          - row "Scorch	1024.10	10.89"
           - row "Essence of Sapphiron	42.00	0.45"
-          - row "Blink	33.60	0.36"
           - row "Melee	30.80	0.33"
-          - row "Total	184967.30	1966.48"
+          - row "Combustion	29.40	0.31"
+          - row "Blink	25.20	0.27"
+          - row "Total	2198.00	23.37"
       `);
   });
 });

--- a/era/threat/unit.js
+++ b/era/threat/unit.js
@@ -109,7 +109,6 @@ export class Unit {
         // Allow applying a coefficient per spellId or via a combination of other buffs
         if (
           typeof this.config.buffMultipliers[buffId] === "object" &&
-          spellId &&
           "coeff" in this.config.buffMultipliers[buffId]
         ) {
           const { coeff } = this.config.buffMultipliers[buffId];

--- a/sod/raid/naxx.js
+++ b/sod/raid/naxx.js
@@ -12,5 +12,5 @@ export {
 // TODO: here is where all the seal stuff will go and updated multipliers/handlers
 
 export const buffMultipliers = {
-  [era.config.Buff.FungalBloom]: getThreatCoefficient(0),
+  ...era.buffMultipliers,
 };

--- a/sod/raid/naxx.spec.ts
+++ b/sod/raid/naxx.spec.ts
@@ -119,7 +119,7 @@ test.describe("/sod/ threat values - Naxx mechanics", () => {
 
       await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
       - textbox
-      - text: "Tombah - Started fight with threat coeff 1.45"
+      - text: "Tombah - Started fight with threat coeff 2.871"
       - table:
           - rowgroup:
               - row "Ability        Threat (*)  Per 74.48 seconds"

--- a/sod/sod-threat.spec.ts
+++ b/sod/sod-threat.spec.ts
@@ -12,7 +12,7 @@ test.describe("/sod/ threat values", () => {
 
     await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
       - textbox
-      - text: "Sheenftw - Started fight with threat coeff 1.495"
+      - text: "Sheenftw - Started fight with threat coeff 1.6445"
       - table:
           - rowgroup:
               - row "Ability        Threat (*)  Per 107.19 seconds"
@@ -84,7 +84,7 @@ test.describe("/sod/ threat values", () => {
 
     await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
       - textbox
-      - text: "Neitsa - Started fight with threat coeff 1.3"
+      - text: "Neitsa - Started fight with threat coeff 1.95"
       - table:
           - rowgroup:
               - row "Ability        Threat (*)  Per 86.47 seconds"
@@ -161,7 +161,7 @@ test.describe("/sod/ threat values", () => {
 
     await expect(page.locator("#threatTableContainer")).toMatchAriaSnapshot(`
       - textbox
-      - text: "Predasmoke - Started fight with threat coeff 1.45"
+      - text: "Predasmoke - Started fight with threat coeff 2.871"
       - table:
           - rowgroup:
               - row "Ability        Threat (*)  Per 58.74 seconds"


### PR DESCRIPTION
Was not appying all buffMultipliers correctly so the starting coefficient was missing important multipliers

Issue: the base coefficient is calculated at the start with an undefined spellId e.g. `unit.threatCoef(undefined)`. This was filtering out `buffMultipliers` that had the custom function form.

Events were still being calculated correctly. It was only the initial coeff that was wrong.

<img width="360" alt="Screenshot 2025-03-04 at 11 13 53 PM" src="https://github.com/user-attachments/assets/7a3c9e53-9a0e-4e0f-9a1a-16c720dbee15" />

| Before | After |
|--------|--------|
| <img width="171" alt="Screenshot 2025-03-04 at 11 14 47 PM" src="https://github.com/user-attachments/assets/a48f1c9b-c683-435c-b7d4-4ace91778ef8" /> | <img width="168" alt="Screenshot 2025-03-04 at 11 13 48 PM" src="https://github.com/user-attachments/assets/dca76b72-9b06-415e-96a7-98a361746776" /> | 





<pr-train-toc>

|     | PR  | Description                             |
| --- | --- | --------------------------------------- |
|     | #38 | [Naxx 3] Era Fungal Bloom               |
| 👉  | #42 | [Era/SoD] Fix starting coefficient      |
|     | #39 | [Naxx 4] SoD Sanctified + Seal handling |

</pr-train-toc>